### PR TITLE
Add Next.js dashboard skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # git-flow
+
+This repository now includes a simple Next.js dashboard application located in `dashboard-app`.
+
+## Dashboard App Features
+- **Next.js** project with TypeScript and routing.
+- **Material UI** integration for styling.
+- **Recharts** for interactive charting.
+- Fetches real-time gold prices from `https://www.goldapi.io` via an API route.
+
+## Running the Dashboard
+1. Install dependencies (requires internet access):
+   ```bash
+   cd dashboard-app
+   npm install
+   npm run dev
+   ```
+2. Open the browser at `http://localhost:3000` to view the dashboard.
+
+Set the environment variable `GOLD_API_KEY` with your API token from goldapi.io.

--- a/dashboard-app/next-env.d.ts
+++ b/dashboard-app/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+

--- a/dashboard-app/next.config.js
+++ b/dashboard-app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/dashboard-app/package.json
+++ b/dashboard-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "dashboard-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@mui/material": "latest",
+    "@emotion/react": "latest",
+    "@emotion/styled": "latest",
+    "recharts": "latest",
+    "cross-fetch": "latest"
+  }
+}

--- a/dashboard-app/src/pages/api/gold-price.ts
+++ b/dashboard-app/src/pages/api/gold-price.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fetch from 'cross-fetch';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const response = await fetch('https://www.goldapi.io/api/XAU/USD', {
+      headers: { 'x-access-token': process.env.GOLD_API_KEY || '' }
+    });
+    const data = await response.json();
+    res.status(200).json({ price: data.price, time: new Date().toISOString() });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch gold price' });
+  }
+}

--- a/dashboard-app/src/pages/index.tsx
+++ b/dashboard-app/src/pages/index.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Typography, Box } from '@mui/material';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+interface GoldPriceResponse {
+  price: number;
+  time: string;
+}
+
+export default function Home() {
+  const [price, setPrice] = useState<number | null>(null);
+  const [history, setHistory] = useState<Array<{ time: string; price: number }>>([]);
+
+  useEffect(() => {
+    fetch('/api/gold-price')
+      .then(res => res.json())
+      .then((data: GoldPriceResponse) => {
+        setPrice(data.price);
+        setHistory(h => [...h.slice(-9), { time: data.time, price: data.price }]);
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Dashboard
+      </Typography>
+      <Box my={2}>
+        <Typography variant="h6">Current Gold Price (USD)</Typography>
+        <Typography variant="body1">{price ? `$${price}` : 'Loading...'}</Typography>
+      </Box>
+      <Box height={300}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={history}>
+            <XAxis dataKey="time" hide={true} />
+            <YAxis domain={['auto', 'auto']} />
+            <Tooltip />
+            <Line type="monotone" dataKey="price" stroke="#8884d8" />
+          </LineChart>
+        </ResponsiveContainer>
+      </Box>
+    </Container>
+  );
+}

--- a/dashboard-app/tsconfig.json
+++ b/dashboard-app/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add README instructions for new dashboard app
- implement minimal Next.js project in `dashboard-app`
- add MUI and Recharts integration
- include API route fetching real-time gold prices

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e59df3a208323a0a1659edc0b60b5