### PR TITLE
Add selectable gold price history range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # git-flow
+
+This repository now includes a simple Next.js dashboard application located in `dashboard-app`.
+
+## Dashboard App Features
+- **Next.js** project with TypeScript and routing.
+- **Material UI** integration for styling.
+- **Recharts** for interactive charting.
+- Fetches gold price history from `https://www.goldapi.io` via an API route. The
+  dashboard lets you toggle between the last 24 hours and last 30 days.
+
+## Running the Dashboard
+1. Install dependencies (requires internet access):
+   ```bash
+   cd dashboard-app
+   npm install
+   npm run dev
+   ```
+2. Open the browser at `http://localhost:3000` to view the dashboard.
+
+Set the environment variable `GOLD_API_KEY` with your API token from goldapi.io.

--- a/dashboard-app/next-env.d.ts
+++ b/dashboard-app/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+

--- a/dashboard-app/next.config.js
+++ b/dashboard-app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/dashboard-app/package.json
+++ b/dashboard-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "dashboard-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@mui/material": "latest",
+    "@emotion/react": "latest",
+    "@emotion/styled": "latest",
+    "recharts": "latest",
+    "cross-fetch": "latest"
+  }
+}

--- a/dashboard-app/src/pages/api/gold-price.ts
+++ b/dashboard-app/src/pages/api/gold-price.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fetch from 'cross-fetch';
+
+interface GoldPoint {
+  price: number;
+  time: string;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const { period = '24h' } = req.query;
+    const response = await fetch(
+      `https://www.goldapi.io/api/XAU/USD/history?period=${period}`,
+      {
+        headers: { 'x-access-token': process.env.GOLD_API_KEY || '' }
+      }
+    );
+    const data = await response.json();
+
+    const history: GoldPoint[] = (data || []).map((item: any) => ({
+      price: item.price,
+      time: item.timestamp
+    }));
+
+    res.status(200).json(history);
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch gold price history' });
+  }
+}

--- a/dashboard-app/src/pages/index.tsx
+++ b/dashboard-app/src/pages/index.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Typography, Box, FormControl, Select, MenuItem } from '@mui/material';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer
+} from 'recharts';
+
+interface GoldPricePoint {
+  price: number;
+  time: string;
+}
+
+export default function Home() {
+  const [history, setHistory] = useState<GoldPricePoint[]>([]);
+  const [period, setPeriod] = useState('24h');
+  const latest = history[history.length - 1];
+
+  useEffect(() => {
+    fetch(`/api/gold-price?period=${period}`)
+      .then(res => res.json())
+      .then((data: GoldPricePoint[]) => {
+        setHistory(data);
+      })
+      .catch(() => {});
+  }, [period]);
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Dashboard
+      </Typography>
+      <Box my={2}>
+        <Typography variant="h6">Current Gold Price (USD)</Typography>
+        <Typography variant="body1">
+          {latest ? `$${latest.price}` : 'Loading...'}
+        </Typography>
+      </Box>
+      <Box my={2}>
+        <FormControl size="small">
+          <Select
+            value={period}
+            onChange={e => setPeriod(e.target.value as string)}
+          >
+            <MenuItem value="24h">Last 24 Hours</MenuItem>
+            <MenuItem value="30d">Last 30 Days</MenuItem>
+          </Select>
+        </FormControl>
+      </Box>
+      <Box height={300}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={history}>
+            <XAxis dataKey="time" hide={true} />
+            <YAxis domain={['auto', 'auto']} />
+            <Tooltip />
+            <Line type="monotone" dataKey="price" stroke="#8884d8" />
+          </LineChart>
+        </ResponsiveContainer>
+      </Box>
+    </Container>
+  );
+}

--- a/dashboard-app/tsconfig.json
+++ b/dashboard-app/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- let dashboard toggle between last 24 hours and last 30 days
- accept `period` query param in the gold price API route
- document range selection in the README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e59df3a208323a0a1659edc0b60b5